### PR TITLE
Fix region and make credentials optional

### DIFF
--- a/src/main/scala/com/hivehome/kafka/connect/sqs/Conf.scala
+++ b/src/main/scala/com/hivehome/kafka/connect/sqs/Conf.scala
@@ -48,14 +48,14 @@ object Conf {
   val ConfigDef = new ConfigDef()
     .define(SourceSqsQueue, Type.STRING, Importance.HIGH, "Source SQS queue name to consumer from.")
     .define(DestinationKafkaTopic, Type.STRING, Importance.HIGH, "Destination Kafka topicName to publish data to")
-    .define(AwsKey, Type.STRING, Importance.MEDIUM, "AWS Key to connect to SQS")
-    .define(AwsSecret, Type.STRING, Importance.MEDIUM, "AWS secret to connect to SQS")
+    .define(AwsKey, Type.STRING, "", Importance.MEDIUM, "AWS Key to connect to SQS")
+    .define(AwsSecret, Type.STRING, "", Importance.MEDIUM, "AWS secret to connect to SQS")
 
   def parse(props: Map[String, String]): Try[Conf] = Try {
     val queueName = props.get(Conf.SourceSqsQueue)
     val topicName = props.get(Conf.DestinationKafkaTopic)
-    val awsKey = props.get(Conf.AwsKey)
-    val awsSecret = props.get(Conf.AwsSecret)
+    val awsKey = props.get(Conf.AwsKey).filter(_.nonEmpty)
+    val awsSecret = props.get(Conf.AwsSecret).filter(_.nonEmpty)
     val awsRegion = props.get(Conf.AwsRegion)
 
     if (queueName == null || queueName.isEmpty)

--- a/src/main/scala/com/hivehome/kafka/connect/sqs/Conf.scala
+++ b/src/main/scala/com/hivehome/kafka/connect/sqs/Conf.scala
@@ -29,12 +29,13 @@ case class Conf(queueName: Option[String] = None,
                 awsSecret: Option[String] = None) {
   def toMap: Map[String, String] = {
     import Conf._
-    Map[String, Option[String]]()
-      .updated(SourceSqsQueue, queueName)
-      .updated(DestinationKafkaTopic, topicName)
-      .updated(AwsKey, awsKey)
-      .updated(AwsSecret, awsSecret)
-      .collect { case (k, Some(v)) => (k, v) }
+    Map[String, Option[String]](
+      SourceSqsQueue -> queueName,
+      DestinationKafkaTopic -> topicName,
+      AwsKey -> awsKey,
+      AwsSecret -> awsSecret,
+      AwsRegion -> Some(awsRegion)
+    ).collect { case (k, Some(v)) => (k, v) }
   }
 }
 


### PR DESCRIPTION
This PR addresses 2 issues with this project.

1) It makes AWS credentials optional. This is important when the user wants to use a different credentials mechanism than a Key and Secret, such as instance roles. See: https://github.com/ConnectedHomes/sqs-kafka-connect/issues/5

2) It removes an implicit hardcoding to use eu-west-1. As is, the AWS region can be defined, but `Conf.toMap` does not include this region in its returned map. As a result, each connector task tries to use `eu-west-1`. See: https://github.com/ConnectedHomes/sqs-kafka-connect/issues/4
